### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: otherosfs
 Priority: optional
 Maintainer: Dan Hasting <maintainer@hasting.email>
 Build-Depends: debhelper-compat (= 13), cmake, libgl1-mesa-dev, libopenal-dev
-Standards-Version: 4.5.0
+Standards-Version: 4.6.0
 Homepage: https://www.cen64.com/
 Vcs-Git: https://github.com/dh4/cen64-debian.git
 Vcs-Browser: https://github.com/dh4/cen64-debian/

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: otherosfs
 Priority: optional
 Maintainer: Dan Hasting <maintainer@hasting.email>
 Build-Depends: debhelper-compat (= 13), cmake, libgl1-mesa-dev, libopenal-dev
-Standards-Version: 4.6.0
+Standards-Version: 4.6.2
 Homepage: https://www.cen64.com/
 Vcs-Git: https://github.com/dh4/cen64-debian.git
 Vcs-Browser: https://github.com/dh4/cen64-debian/

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: cen64
 Section: otherosfs
 Priority: optional
 Maintainer: Dan Hasting <maintainer@hasting.email>
-Build-Depends: debhelper-compat (= 12), cmake, libgl1-mesa-dev, libopenal-dev
+Build-Depends: debhelper-compat (= 13), cmake, libgl1-mesa-dev, libopenal-dev
 Standards-Version: 4.5.0
 Homepage: https://www.cen64.com/
 Vcs-Git: https://github.com/dh4/cen64-debian.git

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,2 @@
-version=3
+version=4
 https://github.com/n64dev/cen64/tags .*/v?(\d.*)\.(?:tgz|tbz2|tar\.(?:gz|bz2|xz))


### PR DESCRIPTION
Fix some issues reported by lintian

* Update watch file format version to 4. ([older-debian-watch-file-standard](https://lintian.debian.org/tags/older-debian-watch-file-standard))
* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))
* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/8dad10dc-fe03-410e-ae38-0fd70f15b9da/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/8dad10dc-fe03-410e-ae38-0fd70f15b9da/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/8dad10dc-fe03-410e-ae38-0fd70f15b9da/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/8dad10dc-fe03-410e-ae38-0fd70f15b9da.